### PR TITLE
Fix AssuranceCertificationMatcher abstract bean

### DIFF
--- a/src/main/resources/uk/org/ukfederation/mda/beans.xml
+++ b/src/main/resources/uk/org/ukfederation/mda/beans.xml
@@ -87,7 +87,7 @@
     <bean id="ukf.EntityAttributeAddingStage" abstract="true" parent="ukf.stage_parent"
         class="uk.org.ukfederation.mda.dom.saml.mdattr.EntityAttributeAddingStage"/>
         
-    <bean id="ukf.AssuranceCertificationMatcher" abstract="true" parent="ukf.stage_parent"
+    <bean id="ukf.AssuranceCertificationMatcher" abstract="true"
         class="uk.org.ukfederation.mda.dom.saml.mdattr.AssuranceCertificationMatcher"/>
 
     <!--


### PR DESCRIPTION
Remove parent ukf.stage_parent from AssuranceCertificationMatcher abstract bean.
The bean is a predicate and not a stage/component.