### PR TITLE
Add Java 11 Maven verify Action

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,0 +1,33 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Java CI with Maven
+
+# Only 'this' branch will execute this action when pushed to or a PR is created, so the 'on' is not strictly required but are added as 
+# an extra layer of protection to ensure the correct Java version is run
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'corretto'      
+        java-version: '11'
+        cache: 'maven'
+    - name: Build with Maven
+      run: mvn -B verify checkstyle:checkstyle --file pom.xml
+    - name: Upload jar artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ukf-mda-snapshot
+        path: target/ukf-mda*.jar

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.shibboleth</groupId>
         <artifactId>parent</artifactId>
-        <version>11.3.4-SNAPSHOT</version>
+        <version>11.3.5-SNAPSHOT</version>
     </parent>
 
     <groupId>uk.org.ukfederation</groupId>


### PR DESCRIPTION
- This is currently failing because the POM points to `11.3.4-SNAPSHOT` of the java-parent project —— which is no longer being built.
- I've used the `corretto` JDK in this action, the maint-0.9 branch uses the`zulu` JDK. I _think_ that is because the corretto distribution in the Github action did not go back to Java 8, but I might be wrong, and if I am could change that over to corretto as well.