### PR TITLE
Port to Java 17

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,9 +1,9 @@
 # This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: Java CI with Maven (JDK 11)
+name: Java CI with Maven (JDK 17)
 
-# Only 'this' branch will execute this action when pushed to or a PR is created, so the 'on' is not strictly required but are added as 
+# Only 'this' branch will execute this action when pushed to or a PR is created, so the 'on' is not strictly required but are added as
 # an extra layer of protection to ensure the correct Java version is run
 on:
   push:
@@ -18,11 +18,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        distribution: 'corretto'      
-        java-version: '11'
+        distribution: 'corretto'
+        java-version: '17'
         cache: 'maven'
     - name: Build with Maven
       run: mvn -B verify checkstyle:checkstyle --file pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>net.shibboleth</groupId>
         <artifactId>parent</artifactId>
-        <version>11.3.5-SNAPSHOT</version>
+        <version>17.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>uk.org.ukfederation</groupId>
@@ -25,6 +25,8 @@
     <properties>
         <mda.version>0.10.0-SNAPSHOT</mda.version>
         <ukf-members.version>1.5.0</ukf-members.version>
+        <jakarta.jaxb-api.version>2.3.3</jakarta.jaxb-api.version>
+        <jakarta.jaxb-impl.version>2.3.6</jakarta.jaxb-impl.version>
     </properties>
 
     <repositories>
@@ -88,16 +90,12 @@
             <artifactId>bcprov-jdk15on</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.velocity</groupId>
-            <artifactId>velocity-engine-core</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.cryptacular</groupId>
             <artifactId>cryptacular</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-core</artifactId>
+            <groupId>${slf4j.groupId}</groupId>
+            <artifactId>slf4j-api</artifactId>
         </dependency>
 
         <!--
@@ -117,11 +115,6 @@
         <!-- Test dependencies -->
 
         <dependency>
-            <groupId>com.sun.activation</groupId>
-            <artifactId>jakarta.activation</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
             <scope>test</scope>
@@ -132,6 +125,11 @@
             <artifactId>mda-framework</artifactId>
             <version>${mda.version}</version>
             <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Move to the new Shibboleth parent POM to adopt Java 17.

For now, explicitly use the old jaxb API rather than moving to the new Jakarta namespace, as we're still using a legacy ukf-members implementation.